### PR TITLE
Change packaging order

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ suggested by Hadley Wickham in:
 
 Some useful keyboard shortcuts for package authoring:
 
+* Update Documentation:      `Cmd + Shift + D` or `roxygen2::roxygenise()`
 * Build and Reload Package:  `Cmd + Shift + B`
-* Update Documentation:      `Cmd + Shift + D` or `devtools::document()`
 * Test Package:              `Cmd + Shift + T`
 * Check Package:             `Cmd + Shift + E` or `devtools::check()`
 


### PR DESCRIPTION
Changed `devtools::document()` to `roxygen2::roxygenise()` just to generate the documentation and not compile the Rcpp.

Since we are excluding files generated by roxygen. The required file NAMESPACE will not be available until before running `devtools::document()` or `roxygen2::roxygenise()`